### PR TITLE
fix(enum-translations): move translations under pluralized attribute key

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ en:
   activerecord:
    attributes:
     purchase:
-      payment_method:
+      payment_methods:
         credit: "Credit Card"
         debit: "Debit Card"
         cash: "Cash"
@@ -307,7 +307,7 @@ If you want to use the same enum translations for multiple models, use this loca
 en:
   enum:
     default:
-      payment_method:
+      payment_methods:
         credit: "Credit Card"
         debit: "Debit Card"
         cash: "Cash"

--- a/lib/human_attributes/formatters/enum.rb
+++ b/lib/human_attributes/formatters/enum.rb
@@ -7,8 +7,9 @@ module HumanAttributes
         is_enum_defined = _instance.class.defined_enums.has_key?(attribute.to_s)
         raise_error('NotEnumAttribute') unless is_enum_defined
         class_name = _instance.class.name.underscore
-        attr_key = "activerecord.attributes.#{class_name}.#{attribute}.#{value}"
-        enum_key = "enum.defaults.#{attribute}.#{value}"
+        pluralized_attribute = attribute.to_s.pluralize
+        attr_key = "activerecord.attributes.#{class_name}.#{pluralized_attribute}.#{value}"
+        enum_key = "enum.defaults.#{pluralized_attribute}.#{value}"
         translate(attr_key, translate(enum_key, value))
       end
 

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -35,13 +35,13 @@ en:
     negative: "No"
   enum:
     defaults:
-      shipping:
+      shippings:
           standard: "Standard"
           express: "Express"
   activerecord:
    attributes:
     purchase:
-      payment_method:
+      payment_methods:
         credit: "Credit Card"
         debit: "Debit Card"
         cash: "Cash"


### PR DESCRIPTION
### Context
We had previously added  support for rails enums, but it wasn't working as expected. The problem was that the enum keys for translations were under a singular attribute name instead of pluralized.  We want to move translations of enum under a pluralized attribute name in order to keep the format of translations that we already use for enums and to keep translation of the attribute name too. 

### What has been done
The pluralization of the attribute name was added to find the translation path.

### In particular you have to check
This small change in the enum fomatter.