### PR TITLE
Fix/enums ruby 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,12 @@ To run the specs you need to execute, **in the root path of the gem**, the follo
 bundle exec guard
 ```
 
+To run all the specs of the gem, **in the root path of the gem**, the following command:
+
+```bash
+bundle exec rspec
+```
+
 You need to put **all your tests** in the `/human_attributes/spec/dummy/spec/` directory.
 
 ## Publishing

--- a/lib/human_attributes/formatters/enum.rb
+++ b/lib/human_attributes/formatters/enum.rb
@@ -14,7 +14,7 @@ module HumanAttributes
       end
 
       def translate(key, default)
-        I18n.t(key,  { default: default })
+        I18n.t(key,  default: default)
       end
 
       def enum_defined?(_instance)


### PR DESCRIPTION
### Context
Enums humanizer wasn't working for projects with ruby 3. The problem was that for ruby 3 using the last argument as keyworded params is deprecated. 

### What has been done
The enum formatter was fixed to use the ruby3 syntax for keyworded arguments. Also It was added to the README the explanation of how to run all the tests . 

### In particular you have to check
This small change  in the enum formatter.

### More information
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

